### PR TITLE
Fix Issue #8: Remove redundant trait definitions for Trait

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -67,12 +67,8 @@ unsafe impl<T, I> Trait for ::std::iter::IntoIterator<IntoIter=I, Item=T> { }
 unsafe impl<T> Trait for ::std::iter::Iterator<Item=T> + Send { }
 unsafe impl<T> Trait for ::std::iter::Iterator<Item=T> + Sync { }
 unsafe impl<T> Trait for ::std::iter::Iterator<Item=T> + Send + Sync { }
-unsafe impl Trait for ::std::marker::Send + Send { }
-unsafe impl Trait for ::std::marker::Send + Sync { }
-unsafe impl Trait for ::std::marker::Send + Send + Sync { }
-unsafe impl Trait for ::std::marker::Sync + Send { }
-unsafe impl Trait for ::std::marker::Sync + Sync { }
-unsafe impl Trait for ::std::marker::Sync + Send + Sync { }
+unsafe impl Trait for Send { }
+unsafe impl Trait for Sync { }
 unsafe impl Trait for ::std::ops::Drop + Send { }
 unsafe impl Trait for ::std::ops::Drop + Sync { }
 unsafe impl Trait for ::std::ops::Drop + Send + Sync { }


### PR DESCRIPTION
Fix redundant Trait impl's that are causing issue #8 

see: https://github.com/reem/rust-traitobject/issues/8